### PR TITLE
Code sign and notarize macOS binaries

### DIFF
--- a/.github/workflows/test_and_release.yaml
+++ b/.github/workflows/test_and_release.yaml
@@ -188,25 +188,43 @@ jobs:
           message(FATAL_ERROR "Bad exit status")
         endif()
         execute_process(COMMAND ccache -s)
-    - if: ${{ runner.os=='Windows'}}
+    - if: ${{ runner.os=='Windows' }}
       name: Run Tests (Windows)
       run: |
         & .\build\tests\${Env:PROJECT_NAME}_Tests.exe
-    - if: ${{ runner.os!='Windows'}}
+    - if: ${{ runner.os!='Windows' }}
       name: Run Tests (Unix)
       run: |
         ./build/tests/${PROJECT_NAME}_Tests
-    - if: ${{ runner.os=='Windows'}}
+    - if: ${{ runner.os=='Windows' }}
       name: Run Benchmark (Windows)
-      # Use benchmark as test for now
       run: |
         & .\build\benchmark\${Env:PROJECT_NAME}_Benchmark_artefacts\${Env:BUILD_TYPE}\${Env:PROJECT_NAME}_Benchmark.exe
-    - if: ${{ runner.os!='Windows'}}
+    - if: ${{ runner.os!='Windows' }}
       name: Run Benchmark (Unix)
-      # Use benchmark as test for now
       run: |
         ./build/benchmark/${PROJECT_NAME}_Benchmark_artefacts/${BUILD_TYPE}/${PROJECT_NAME}_Benchmark
-    - if: ${{ runner.os=='Windows'}}
+    - if: ${{ runner.os=='macOS' }}
+      name: Import Code-Signing Certificates
+      uses: Apple-Actions/import-codesign-certs@v1
+      with:
+        # The certificates in a PKCS12 file encoded as a base64 string
+        p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
+        # The password used to import the PKCS12 file.
+        p12-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+    - if: ${{ runner.os=='macOS' }}
+      name: Install gon via HomeBrew for code signing and app notarization
+      run: |
+        brew tap mitchellh/gon
+        brew install mitchellh/gon/gon
+    - if: ${{ runner.os=='macOS' }}
+      name: Sign the mac binaries with Gon
+      env:
+        AC_USERNAME: ${{ secrets.AC_USERNAME }}
+        AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+      run: |
+        gon -log-level=debug -log-json ./gon.json
+    - if: ${{ runner.os=='Windows' }}
       name: Pack (Windows)
       run: |
         mkdir ${{ github.event.repository.name }}-${{ runner.os }}
@@ -215,20 +233,27 @@ jobs:
         move * ..\..\..\..\${{ github.event.repository.name }}-${{ runner.os }}
         cd ..\..\..\..
         cmake -E tar cvf ${{ github.event.repository.name }}-${{ runner.os }}.zip --format=zip -- ${{ github.event.repository.name }}-${{ runner.os }}
-    - if: ${{ runner.os!='Windows'}}
-      name: Pack (Unix)
+    - if: ${{ runner.os=='Linux' }}
+      name: Pack (Linux)
       run: |
-        mkdir ${{ github.event.repository.name }}-${{ runner.os }}
+        mkdir -p ${{ github.event.repository.name }}-${{ runner.os }}
         cd build/src/*_artefacts/Release
         rm *.*
         mv * ../../../../${{ github.event.repository.name }}-${{ runner.os }}
         cd ../../../..
         cmake -E tar cvf ${{ github.event.repository.name }}-${{ runner.os }}.zip --format=zip -- ${{ github.event.repository.name }}-${{ runner.os }}
-    - name: Upload
+    - if: ${{ runner.os!='macOS' }}
+      name: Upload (Windows and Linux)
       uses: actions/upload-artifact@v2
       with:
         name: ${{ github.event.repository.name }}-${{ runner.os }}
         path: ${{ github.event.repository.name }}-${{ runner.os }}.zip
+    - if: ${{ runner.os=='macOS' }}
+      name: Upload (macOS)
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.event.repository.name }}-${{ runner.os }}
+        path: ${{ github.event.repository.name }}-${{ runner.os }}.dmg
 
   release:
     if: contains(github.ref, 'tags/v')
@@ -265,15 +290,18 @@ jobs:
         config:
         - {
             name: "Windows Latest MSVC", artifact: "Windows",
-            os: ubuntu-latest
+            os: ubuntu-latest,
+            extention: "zip", contenttype: "application/zip"
           }
         - {
             name: "Ubuntu Latest GCC", artifact: "Linux",
-            os: ubuntu-latest
+            os: ubuntu-latest,
+            extention: "zip", contenttype: "application/zip"
           }
         - {
             name: "macOS Latest Clang", artifact: "macOS",
-            os: ubuntu-latest
+            os: ubuntu-latest,
+            extention: "dmg", contenttype: "application/octet-stream"
           }
     needs: release
 
@@ -301,6 +329,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.set_upload_url.outputs.upload_url }}
-        asset_path: ./${{ github.event.repository.name }}-${{ matrix.config.artifact }}.zip
-        asset_name: ${{ github.event.repository.name }}-${{ matrix.config.artifact }}.zip
-        asset_content_type: application/zip
+        asset_path: ./${{ github.event.repository.name }}-${{ matrix.config.artifact }}.${{ matrix.config.extention }}
+        asset_name: ${{ github.event.repository.name }}-${{ matrix.config.artifact }}.${{ matrix.config.extention }}
+        asset_content_type: ${{ matrix.config.contenttype }}

--- a/gon.json
+++ b/gon.json
@@ -1,0 +1,18 @@
+{
+  "source" : [
+    "./build/src/Os251_artefacts/Release/Standalone/OS-251.app",
+    "./build/src/Os251_artefacts/Release/VST3/OS-251.vst3",
+    "./build/src/Os251_artefacts/Release/AU/OS-251.component"
+    ],
+  "bundle_id" : "onsenaudio.OS-251",
+  "apple_id": {
+      "password":  "@env:AC_PASSWORD"
+  },
+  "sign" :{
+      "application_identity" : "13A1AEE61409B53A0A1B425960E9AE3279110B8F"
+  },
+  "dmg" :{
+    "output_path":  "./OS-251-macOS.dmg",
+    "volume_name":  "OS-251"
+  }
+}


### PR DESCRIPTION
## Issue
https://github.com/utokusa/OS-251/issues/4

## Change
- Code sign and notarize macOS binaries using [gon](https://github.com/mitchellh/gon)
- Change the release file format for macOS from .zip to .dmg

https://www.kencochrane.com/2020/08/01/build-and-sign-golang-binaries-for-macos-with-github-actions/