### PR TITLE
Add LV2 version for Linux

### DIFF
--- a/.github/workflows/test_and_release.yaml
+++ b/.github/workflows/test_and_release.yaml
@@ -51,6 +51,7 @@ jobs:
         sudo apt-get install -y g++ libgtk-3-dev libfreetype6-dev libx11-dev libxinerama-dev libxrandr-dev libxcursor-dev mesa-common-dev libasound2-dev freeglut3-dev libxcomposite-dev libcurl4-openssl-dev
         sudo add-apt-repository -y ppa:webkit-team && sudo apt-get update
         sudo apt-get install libwebkit2gtk-4.0-37 libwebkit2gtk-4.0-dev
+        sudo apt-get install lv2-dev 
     - name: Download Ninja and CMake
       id: cmake_and_ninja
       shell: cmake -P {0}
@@ -304,6 +305,7 @@ jobs:
         cp ./distro/Linux/readme.txt ${{ github.event.repository.name }}-${{ runner.os }}
         cd build/src/Os251_artefacts/Release
         mv VST3/* ../../../../${{ github.event.repository.name }}-${{ runner.os }}
+        mv LV2/* ../../../../${{ github.event.repository.name }}-${{ runner.os }}
         cd ../../../..
         cmake -E tar cvf ${{ github.event.repository.name }}-${{ runner.os }}.zip --format=zip -- ${{ github.event.repository.name }}-${{ runner.os }}
     - if: ${{ runner.os!='macOS' }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "lib/JUCE"]
 	path = lib/JUCE
-	url = https://github.com/juce-framework/JUCE
-	branch = juce6
+	url = https://github.com/lv2-porting-project/JUCE
+	branch = 6.1.0-lv2
 	ignore = dirty
 
 [submodule "lib/react-juce"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment target")
 
 PROJECT(OS_251
-        LANGUAGES CXX
+        LANGUAGES CXX C
         VERSION 1.0.1
         )
 

--- a/distro/Linux/readme.txt
+++ b/distro/Linux/readme.txt
@@ -2,9 +2,11 @@
 = Install =
 ===========
 1. Unzip OS-251-Linux.zip
-2. Copy OS-251.vst3 to /usr/lib/vst3/
+2. Copy OS-251.vst3 to /usr/lib/vst3/ (sudo cp -r OS-251.vst3 /usr/lib/vst3/)
+3. Copy OS-251.lv2 to /usr/lib/lv2/ (sudo cp -r OS-251.lv2 /usr/lib/lv2/)
 
 =============
 = Uninstall =
 =============
-1. Delete /usr/lib/vst3/OS-251.vst3
+1. Delete /usr/lib/vst3/OS-251.vst3 (sudo rm -rf /usr/lib/vst3/OS-251.vst3)
+2. Delete /usr/lib/lv2/OS-251.lv2 (sudo rm -rf /usr/lib/lv2/OS-251.lv2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,14 @@ else()
     message(STATUS "AAX Build is disabled. To enable, set AAX_SDK_PATH to your environment variable or specify -DAAX_SDK_PATH to CMake configure option.")
 endif()
 
+# default plugin formats
+set(JUCE_FORMATS AU VST3 Standalone ${AAX_BUILD_FLAG})
+# Build LV2 only on Linux
+if(UNIX AND NOT APPLE)
+    message(STATUS "Building LV2 plugin format")
+    list(APPEND JUCE_FORMATS LV2)
+endif()
+
 juce_add_plugin(Os251
         # VERSION ...                                     # Set this if the plugin version is different to the project version
         # ICON_BIG ""   # ICON_* arguments specify a path to an image file to use as an icon for the Standalone
@@ -26,18 +34,13 @@ juce_add_plugin(Os251
         COPY_PLUGIN_AFTER_BUILD TRUE        # Should the plugin be installed to a default location after building?
         PLUGIN_MANUFACTURER_CODE htMi               # A four-character manufacturer id with at least one upper-case character
         PLUGIN_CODE osSY                            # A unique four-character plugin id with at least one upper-case character
-        FORMATS
-        # The formats to build. Other valid formats are: AAX Unity VST AU AUv3
-        Standalone
-        AU
-        # AUv3
-        VST3
-        # Unity
-        ${AAX_BUILD_FLAG}
+        FORMATS ${JUCE_FORMATS}
         VST3_CATEGORIES "Instrument"
         AU_MAIN_TYPE "kAudioUnitType_MusicDevice"
         # AU_SANDBOX_SAFE TRUE
         # AAX_CATEGORY ""
+        LV2_URI https://github.com/utokusa/OS-251
+        LV2_SHARED_LIBRARY_NAME os251lv2
         # HARDENED_RUNTIME_ENABLED # macOS app settings
         # HARDENED_RUNTIME_OPTIONS
         # APP_SANDBOX_ENABLED


### PR DESCRIPTION
Resource: https://jatinchowdhury18.medium.com/building-lv2-plugins-with-juce-and-cmake-d1f8937dbac3

An error was shown wtih vscode-cmake-tools ("Element with id ... is already registered"), but it will  be fixed in https://github.com/microsoft/vscode-cmake-tools/issues/2110