### PR TITLE
Build universal binary instead of x86_64 binary for mac

### DIFF
--- a/.github/workflows/test_and_release.yaml
+++ b/.github/workflows/test_and_release.yaml
@@ -7,7 +7,7 @@ on: [push, pull_request]
 
 env:
   PROJECT_NAME: Os251
-  CMAKE_VERSION: 3.16.2
+  CMAKE_VERSION: 3.22.2
   NINJA_VERSION: 1.9.0
   BUILD_TYPE: Release
   CCACHE_VERSION: 3.7.7
@@ -61,16 +61,16 @@ jobs:
         message(STATUS "Using host CMake version: ${CMAKE_VERSION}")
         if ("${{ runner.os }}" STREQUAL "Windows")
           set(ninja_suffix "win.zip")
-          set(cmake_suffix "win64-x64.zip")
-          set(cmake_dir "cmake-${cmake_version}-win64-x64/bin")
+          set(cmake_suffix "windows-x86_64.zip")
+          set(cmake_dir "cmake-${cmake_version}-windows-x86_64/bin")
         elseif ("${{ runner.os }}" STREQUAL "Linux")
           set(ninja_suffix "linux.zip")
-          set(cmake_suffix "Linux-x86_64.tar.gz")
-          set(cmake_dir "cmake-${cmake_version}-Linux-x86_64/bin")
+          set(cmake_suffix "linux-x86_64.tar.gz")
+          set(cmake_dir "cmake-${cmake_version}-linux-x86_64/bin")
         elseif ("${{ runner.os }}" STREQUAL "macOS")
           set(ninja_suffix "mac.zip")
-          set(cmake_suffix "Darwin-x86_64.tar.gz")
-          set(cmake_dir "cmake-${cmake_version}-Darwin-x86_64/CMake.app/Contents/bin")
+          set(cmake_suffix "macos-universal.tar.gz")
+          set(cmake_dir "cmake-${cmake_version}-macos-universal/CMake.app/Contents/bin")
         endif()
         set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v${ninja_version}/ninja-${ninja_suffix}")
         file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)

--- a/.github/workflows/test_and_release.yaml
+++ b/.github/workflows/test_and_release.yaml
@@ -22,7 +22,7 @@ jobs:
         config:
         - {
             name: "Windows Latest MSVC",
-            os: windows-latest,
+            os: windows-2019,
             cc: "cl", cxx: "cl",
             environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
           }
@@ -242,7 +242,7 @@ jobs:
         # Mount packages image
         hdiutil attach Packages.dmg
         # Install Packages
-        sudo installer -pkg /Volumes/Packages\ 1.2.9/Install\ Packages.pkg -target /
+        sudo installer -pkg /Volumes/Packages\ 1.2.10/Install\ Packages.pkg -target /
     - if: ${{ runner.os=='macOS' }}
       name: Create .pkg (macOS)
       run: |
@@ -267,8 +267,11 @@ jobs:
     - if: ${{ runner.os=='macOS' }}
       name: Install gon via HomeBrew for code signing and app notarization
       run: |
-        brew tap mitchellh/gon
-        brew install mitchellh/gon/gon
+        # We need to use a fork because of https://github.com/mitchellh/homebrew-gon/pull/1
+        # brew tap mitchellh/gon
+        # brew install mitchellh/gon/gon
+        brew tap mistydemeo/gon
+        brew install mistydemeo/gon/gon
     - if: ${{ runner.os=='macOS' }}
       name: Nortalize .pkg with Gon
       env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.20)
 set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment target")
+set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build as universal binary")
 
 PROJECT(OS_251
         LANGUAGES CXX C

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20)
 include(GoogleTest)
 
 # Tests


### PR DESCRIPTION
## Changes
- Build universal binary instead of x64 binary for mac
- Fix GitHub Actions

## Test
- [x] macOS 12.3 (Monterey)/arm64/Live11/vst3
- [x] macOS 12.3 (Monterey)//arm64/Live11/auv2
- [x] macOS 12.3 (Monterey)//arm64/Logic Pro/auv2
- [x] macOS 10.14 (Mojave)/x86_64/Live10
- [x] macOS 10.12 (Sierra)/x86_64/Live10

## Resources
- https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
- https://stackoverflow.com/questions/65157483/macos-build-universal-binary-2-with-cmake

## TODOs
- Use windows-latest for github actions again