### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build as universal bina
 
 PROJECT(OS_251
         LANGUAGES CXX C
-        VERSION 1.1.0
+        VERSION 1.1.1
         )
 
 add_compile_definitions(OS_251_PROJECT_VERSION="${PROJECT_VERSION}")

--- a/distro/Windows/OS-251.iss
+++ b/distro/Windows/OS-251.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=OS-251
-AppVersion=1.1.0
+AppVersion=1.1.1
 DefaultDirName={commonpf}\Onsen Audio\OS-251
 DefaultGroupName=OS-251
 OutputBaseFilename=OS-251-Windows


### PR DESCRIPTION
## Important changes
- Avoid to take keyboard focus
- Build universal binary instead of x64 binary for mac

## Test (specific to this version)
- [x] Even after changing parameter values from the  OS-251's UI, you can do play/stop DAW using its shortcut.
- [x] universal binary is created
```bash
% lipo -archs OS-251.component/Contents/MacOS/OS-251 
x86_64 arm64
% lipo -archs OS-251.vst3/Contents/MacOS/OS-251 
x86_64 arm64
```
- [x] Saved preset has correct `SavedByVersion` value `<SavedByVersion>1.1.1</SavedByVersion>`


## Test targets
- [x] macOS 12.3 (Monterey)//arm64/Live11
- [x] macOS 12.3 (Monterey)//arm64/Logic Pro
- [x] macOS 10.15 (Catalina)/x86_64/Live11
- [x] macOS 10.15 (Catalina)/x86_64/Logic Pro
- [x] macOS 10.15 (Catalina)/x86_64/FL Studio 20
- [x] macOS 10.15 (Catalina)/x86_64/Studio One 4
- [x] macOS 10.14 (Mojave)/x86_64/Live10
- [x] macOS 10.12 (Sierra)/x86_64/Live10
- [x] Ubuntu 21.10/x86_64/Ardour-6.9.0
- [x] Ubuntu 21.10/x86_64/Bitwig Studio
- [x] Ubuntu 21.10/x86_64/Waveform 11
- [x] Ubuntu 21.10/x86_64/Zrythm
- [x] Windows 10/x86_64/Live11