### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12" CACHE STRING "Minimum OS X deployment ta
 
 PROJECT(OS_251
         LANGUAGES CXX C
-        VERSION 1.1.1
+        VERSION 1.2.0
         )
 
 add_compile_definitions(OS_251_PROJECT_VERSION="${PROJECT_VERSION}")

--- a/assets/presets/Default.oapreset
+++ b/assets/presets/Default.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Bass/Bass0.oapreset
+++ b/assets/presets/Factory/Bass/Bass0.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Bass/Bass1.oapreset
+++ b/assets/presets/Factory/Bass/Bass1.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Bass/Bass2.oapreset
+++ b/assets/presets/Factory/Bass/Bass2.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Bass/Bass3.oapreset
+++ b/assets/presets/Factory/Bass/Bass3.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/FX/FX0.oapreset
+++ b/assets/presets/Factory/FX/FX0.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/FX/FX1.oapreset
+++ b/assets/presets/Factory/FX/FX1.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/FX/FX2.oapreset
+++ b/assets/presets/Factory/FX/FX2.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/FX/FX3.oapreset
+++ b/assets/presets/Factory/FX/FX3.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Key/Key0.oapreset
+++ b/assets/presets/Factory/Key/Key0.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Key/Key1.oapreset
+++ b/assets/presets/Factory/Key/Key1.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Key/Key2.oapreset
+++ b/assets/presets/Factory/Key/Key2.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Key/Key3.oapreset
+++ b/assets/presets/Factory/Key/Key3.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Pad/Pad0.oapreset
+++ b/assets/presets/Factory/Pad/Pad0.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Pad/Pad1.oapreset
+++ b/assets/presets/Factory/Pad/Pad1.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Pad/Pad2.oapreset
+++ b/assets/presets/Factory/Pad/Pad2.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/assets/presets/Factory/Pad/Pad3.oapreset
+++ b/assets/presets/Factory/Pad/Pad3.oapreset
@@ -2,7 +2,7 @@
 
 <Preset>
   <Gadget>OS-251</Gadget>
-  <SavedByVersion>1.1.1</SavedByVersion>
+  <SavedByVersion>1.2.0</SavedByVersion>
   <Version>0</Version>
   <State>
     <OS-251>

--- a/distro/Windows/OS-251.iss
+++ b/distro/Windows/OS-251.iss
@@ -1,6 +1,6 @@
 [Setup]
 AppName=OS-251
-AppVersion=1.1.1
+AppVersion=1.2.0
 DefaultDirName={commonpf}\Onsen Audio\OS-251
 DefaultGroupName=OS-251
 OutputBaseFilename=OS-251-Windows


### PR DESCRIPTION
## Important changes
- Add "unison" parameter
- Add clipping indicator
- Stop calculating oscillator value when its gain is zero

## Test targets
- [x] macOS 12.3 (Monterey)//arm64/Live11
- [x] macOS 12.3 (Monterey)//arm64/Logic Pro
- [x] macOS 10.15 (Catalina)/x86_64/Live11
- [x] macOS 10.15 (Catalina)/x86_64/Logic Pro
- [x] macOS 10.15 (Catalina)/x86_64/FL Studio 20
- [x] macOS 10.15 (Catalina)/x86_64/Studio One 4
- [x] macOS 10.14 (Mojave)/x86_64/Live10
- [x] macOS 10.12 (Sierra)/x86_64/Live10
- [x] Ubuntu 21.10/x86_64/Ardour-6.9.0
- [x] Ubuntu 21.10/x86_64/Bitwig Studio
- [x] Ubuntu 21.10/x86_64/Waveform 11
- [x] Ubuntu 21.10/x86_64/Zrythm
- [x] Windows 10/x86_64/Live11